### PR TITLE
OPENEUROPA-1408: Add patch for fixing installation process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ It applies some patches on ``drupal/core`` that are needed for development on OP
 
 ## Patches list
 
+- [Patch](https://www.drupal.org/files/issues/outbound_http_requests-2571475-10.patch) for issue [#2571475](https://www.drupal.org/project/drupal/issues/2571475) -
+Outbound HTTP requests fail with KernelTestBase (TNG).
+- [Patch](https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch) for issue [#2599228](https://www.drupal.org/project/drupal/issues/2599228) -
+Programmatically created translatable content type returns SQL error on content creation.
+- [Patch](https://www.drupal.org/files/issues/2018-08-13/2600154-3-60.patch) for issue [#2600154](https://www.drupal.org/project/drupal/issues/2600154) -
+Deprecation warnings in Twig code cause test failures.
 - [Patch](https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch) for issue [#2943172](https://www.drupal.org/project/drupal/issues/2943172) -
 Directories can't be ignored when collecting extensions during PHPUnit tests.
 Symlinks inside the Drupal testing instance result in infinite loops.
-- [Patch](https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch) for issue [#2599228](https://www.drupal.org/project/drupal/issues/2599228) -
-Programmatically created translatable content type returns SQL error on content creation.
-- [Patch](https://www.drupal.org/files/issues/outbound_http_requests-2571475-10.patch) for issue [#2571475](https://www.drupal.org/project/drupal/issues/2571475) -
-Outbound HTTP requests fail with KernelTestBase (TNG).
-- [Patch](https://www.drupal.org/files/issues/2018-08-13/2600154-3-60.patch) for issue [#2600154](https://www.drupal.org/project/drupal/issues/2600154) -
-Deprecation warnings in Twig code cause test failures.
+- [Patch](https://www.drupal.org/files/issues/2019-01-08/2955457-25.patch) for issue [#2955457](https://www.drupal.org/project/drupal/issues/2955457) -
+ConfigFactory static cache gets polluted with data from config overrides
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Deprecation warnings in Twig code cause test failures.
 - [Patch](https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch) for issue [#2943172](https://www.drupal.org/project/drupal/issues/2943172) -
 Directories can't be ignored when collecting extensions during PHPUnit tests.
 Symlinks inside the Drupal testing instance result in infinite loops.
-- [Patch](https://www.drupal.org/files/issues/2019-01-08/2955457-25.patch) for issue [#2955457](https://www.drupal.org/project/drupal/issues/2955457) -
+- [Patch](https://www.drupal.org/files/issues/2019-01-08/2955457-36.patch) for issue [#2955457](https://www.drupal.org/project/drupal/issues/2955457) -
 ConfigFactory static cache gets polluted with data from config overrides
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch",
                 "https://www.drupal.org/project/drupal/issues/2599228": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
-                "https://www.drupal.org/project/drupal/issues/2571475": "https://www.drupal.org/files/issues/outbound_http_requests-2571475-10.patch"
+                "https://www.drupal.org/project/drupal/issues/2571475": "https://www.drupal.org/files/issues/outbound_http_requests-2571475-10.patch",
+                "https://www.drupal.org/project/drupal/issues/2955457": "https://www.drupal.org/files/issues/2018-12-10/drupal-fix_issue_with_configuration_system-2955457-10.patch"
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "https://www.drupal.org/project/drupal/issues/2599228": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "https://www.drupal.org/project/drupal/issues/2600154": "https://www.drupal.org/files/issues/2018-08-13/2600154-3-60.patch",
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch",
-                "https://www.drupal.org/project/drupal/issues/2955457": "https://www.drupal.org/files/issues/2019-01-10/2955457.patch"
+                "https://www.drupal.org/project/drupal/issues/2955457": "https://www.drupal.org/files/issues/2019-01-11/2955457-36.patch"
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "https://www.drupal.org/project/drupal/issues/2599228": "https://www.drupal.org/files/issues/2018-10-01/2599228-SQL_error_on_content_creation-78_0.patch",
                 "https://www.drupal.org/project/drupal/issues/2600154": "https://www.drupal.org/files/issues/2018-08-13/2600154-3-60.patch",
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch",
-                "https://www.drupal.org/project/drupal/issues/2955457": "https://www.drupal.org/files/issues/2019-01-08/2955457-25.patch"
+                "https://www.drupal.org/project/drupal/issues/2955457": "https://www.drupal.org/files/issues/2019-01-10/2955457.patch"
             }
         },
         "installer-paths": {


### PR DESCRIPTION
## OPENEUROPA-1408
Reason in config static cache which record firstly main config but later override config with the same name by config from language/<langcode> folder (language.<langcode> collection).
This is reproducible only by drush site install command. Not reproducible or hard to find why how it could be reproduced through actions in UI.
I have created patch for core https://www.drupal.org/project/drupal/issues/2955457#comment-12888559 . So it fixed by clearing config static cache.
It would be nice to investigate impact of current cache keys. Because currently it does not respect case that static cache could be updated by configs with collection like "language.<langcode>". For example currently in core we have static cache key like: system.date:global_overrides:en .
More details you could find in /core/lib/Drupal/Core/Config/ConfigFactory.php