### PR TITLE
Change version of Drupal to 8.6.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "behat/mink-selenium2-driver": "1.3.x-dev",
         "cweagans/composer-patches": "^1.6",
         "drupal/coder": "^8.2.12",
-        "drupal/core": "8.6.x-dev",
+        "drupal/core": "8.6.8",
         "jcalderonzumba/gastonjs": "^1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
         "mikey179/vfsStream": "^1.2",


### PR DESCRIPTION
## RELEASE 8.6.8

### Description

Creation of the tag release 8.6.8

### Change log

- Changed: Drupal version on Composer. 
