### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,31 +4,34 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
-    - DOCUMENT_ROOT=/test/drupal-core-require-dev
+      - DOCUMENT_ROOT=/test/drupal-core-require-dev
 
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
-    - /cache:/cache
+      - /cache:/cache
     commands:
-    - composer install --ansi --no-suggest --no-progress
+      - composer install --ansi --no-suggest --no-progress
 
   composer-update-lowest:
     group: prepare-update
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
-    - /cache:/cache
+      - /cache:/cache
     commands:
-    - composer update --prefer-lowest --ansi --no-suggest --no-progress
+      - composer update --prefer-lowest --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: lowest
 
 matrix:
   COMPOSER_BOUNDARY:
-  - lowest
-  - highest
+    - lowest
+    - highest
+  PHP_VERSION:
+    - 7.1
+    - 7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.