### PR TITLE
OPENEUROPA-2604: Prepare release 8.8.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "behat/mink-selenium2-driver": "1.3.x-dev",
         "cweagans/composer-patches": "^1.6",
         "drupal/coder": "^8.3.1",
-        "drupal/core": "8.8.x-dev",
+        "drupal/core": "8.8.0",
         "jcalderonzumba/gastonjs": "^1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
         "mikey179/vfsStream": "^1.2",


### PR DESCRIPTION
## OPENEUROPA-2604
### Description

Prepare the 8.8.0 release

### Change log

- Added:
- Changed: Drupal updated to 8.8.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

