### PR TITLE
OPENEUROP-2604: Revert to dev version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.3",
-        "drupal/core": "8.8.3"
+        "drupal/core-dev": "8.8.x",
+        "drupal/core": "8.8.x"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604

### Description

Revert drupal version to dev.
### Change log

- Added:
- Changed: Revert drupal version to dev.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

