### PR TITLE
OPENEUROPA-2604: Update dependencies to follow drupal/core-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.0",
-        "drupal/core": "8.8.0",
-        "php": "^7.1"
+        "drupal/core-dev": "8.8.x-dev",
+        "drupal/core": "8.8.x-dev"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.x-dev",
-        "drupal/core": "8.8.x-dev"
+        "drupal/core-dev": "8.8.0",
+        "drupal/core": "8.8.0"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -6,22 +6,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "behat/mink": "1.7.x-dev",
-        "behat/mink-goutte-driver": "^1.2",
-        "behat/mink-selenium2-driver": "1.3.x-dev",
         "cweagans/composer-patches": "^1.6",
-        "drupal/coder": "^8.3.1",
+        "drupal/core-dev": "8.8.0",
         "drupal/core": "8.8.0",
-        "jcalderonzumba/gastonjs": "^1.0.2",
-        "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
-        "mikey179/vfsStream": "^1.2",
-        "php": "^7.1",
-        "phpunit/phpunit": "^6.5",
-        "phpspec/prophecy": "^1.7",
-        "symfony/css-selector": "^3.4.0",
-        "symfony/phpunit-bridge": "^3.4.3",
-        "symfony/debug": "^3.4.0",
-        "justinrainbow/json-schema": "^5.2"
+        "php": "^7.1"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604
### Description

Update dependencies to follow drupal/core-dev as opposed to the deprecated webflo/drupal-core-require-dev
### Change log

- Added:
- Changed: Update dependencies.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

