### PR TITLE
OPENEUROPA-2604: Prepare release 8.8.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # drupal-core-require-dev
 
-[![Build Status](https://drone.fpfis.eu/api/badges/openeuropa/drupal-core-require-dev/status.svg?branch=8.7.x)](https://drone.fpfis.eu/openeuropa/drupal-core-require-dev)
+[![Build Status](https://drone.fpfis.eu/api/badges/openeuropa/drupal-core-require-dev/status.svg?branch=8.8.x)](https://drone.fpfis.eu/openeuropa/drupal-core-require-dev)
 [![Packagist](https://img.shields.io/packagist/v/openeuropa/drupal-core-require-dev.svg)](https://packagist.org/packages/openeuropa/drupal-core-require-dev)
 
 ``openeuropa/drupal-core-require-dev`` provides the ``require-dev`` dependencies of ``drupal/core`` as a standalone package. It follows the same release cycle and versioning scheme as Drupal core. You should use the same version constraint for it as you use for Drupal core.
@@ -14,12 +14,12 @@ Directories can't be ignored when collecting extensions during PHPUnit tests.
 Symlinks inside the Drupal testing instance result in infinite loops.
 - [Patch](https://www.drupal.org/files/issues/outbound_http_requests-2571475-10.patch) for issue [#2571475](https://www.drupal.org/project/drupal/issues/2571475) -
 Outbound HTTP requests fail with KernelTestBase (TNG).
-                
+
 ## Usage
 
-### Drupal Core 8.7.x
+### Drupal Core 8.8.x
 
-``composer require --dev openeuropa/drupal-core-require-dev ~8.7``
+``composer require --dev openeuropa/drupal-core-require-dev ~8.8``
 
 ## Installation using Docker Compose
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.0",
-        "drupal/core": "8.8.0"
+        "drupal/core-dev": "8.8.1",
+        "drupal/core": "8.8.1"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604
### Description

Prepare release 8.8.1.

### Change log

- Added:
- Changed: Update Drupal dependencies to 8.8.1
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

