### PR TITLE
OPENEUROPA-2604: Prepare release 8.8.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.1",
-        "drupal/core": "8.8.1"
+        "drupal/core-dev": "8.8.2",
+        "drupal/core": "8.8.2"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604
### Description

Prepare release 8.8.2.

### Change log

- Added:
- Changed: Update Drupal dependencies to 8.8.2 
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

