### PR TITLE
OPENEUROPA-2604: Prepare release 8.8.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.2",
-        "drupal/core": "8.8.2"
+        "drupal/core-dev": "8.8.3",
+        "drupal/core": "8.8.3"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604

### Description

Prepare release 8.8.3

### Change log

- Added:
- Changed: Update drupal dependencies to 8.8.3.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

