### PR TITLE
OPENEUROPA-2604: Prepare 8.8.4 release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.x",
-        "drupal/core": "8.8.x"
+        "drupal/core-dev": "8.8.4",
+        "drupal/core": "8.8.4"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604

### Description

Prepare 8.8.4 release.

### Change log

- Added:
- Changed: Update drupal dependencies to 8.8.4
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

