### PR TITLE
OPENEUROPA-2604: Revert to 8.8.x version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.8.4",
-        "drupal/core": "8.8.4"
+        "drupal/core-dev": "8.8.x",
+        "drupal/core": "8.8.x"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA-2604

### Description

Revert to 8.8.x version.

### Change log

- Added:
- Changed: Revert drupal dependencies to dev branches.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

