### PR TITLE
Revert to 9.0.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": ">=7.3",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "9.0.1",
-        "drupal/core": "9.0.1"
+        "drupal/core-dev": "9.0.x",
+        "drupal/core": "9.0.x"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA

### Description

Revert to 9.0.x.

### Change log

- Added:
- Changed: Revert to 9.0.x.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

