### PR TITLE
Revert to 8.9.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "~7.2.0 || ~7.3.0",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.9.1",
-        "drupal/core": "8.9.1"
+        "drupal/core-dev": "8.9.x",
+        "drupal/core": "8.9.x"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## OPENEUROPA

### Description

Revert to 8.9.x.
### Change log

- Added:
- Changed: Revert to 8.9.x.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

