### PR TITLE
EWPP-916: Drupal 9 compatibility fixes for Drupal 8.9

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,5 +43,5 @@ matrix:
     - lowest
     - highest
   PHP_VERSION:
-    - 7.2
     - 7.3
+    - 7.4

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php": "~7.3.0 || ~7.4.0",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "8.9.x",
-        "drupal/core": "8.9.x"
+        "drupal/core-dev": "8.9.13",
+        "drupal/core": "8.9.13"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "~7.2.0 || ~7.3.0",
+        "php": "~7.3.0 || ~7.4.0",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-dev": "8.9.x",
         "drupal/core": "8.9.x"


### PR DESCRIPTION
PHP 7.2 isn't supported by Drupal 8.
See https://www.drupal.org/docs/system-requirements/php-requirements