### PR TITLE
EWPP-916: Drupal 9 compatibility fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,3 +44,4 @@ matrix:
     - highest
   PHP_VERSION:
     - 7.3
+    - 7.4


### PR DESCRIPTION
Drupal 9 supports PHP 7.4.